### PR TITLE
[Docker] make docker image more lightweight

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
 FROM node:10-alpine
 
-RUN apk add --no-cache curl unzip
-
-WORKDIR /tmp
-RUN curl -L -o ./salien.zip https://github.com/meepen/salien-bot/archive/master.zip && \
-	unzip salien.zip && \
-	rm salien.zip
-
 WORKDIR /app
-RUN cp -R /tmp/salien-bot-master/* ./
+
+COPY package.json /app
 
 RUN yarn install
 
-ENTRYPOINT ["node", "headless.js"]
+COPY . /app
+
+CMD ["node", "headless.js"]


### PR DESCRIPTION
We don't need to pull the repo every time we build since the file should be in current build context. This should produce less layers than before.
Note that `yarn install` is now executed before copying the sources to make use of build cache and build even faster!