### PR TITLE
Instructions and examples to run the bot inside a docker added

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,16 @@ This version, by default, will scour all available planets and get the highest E
 node headless --care-for-planet
 ```
 This will make the bot only use the last planet which you were on and allows you to select the planet for the bot to focus on by first logging onto the Steam website and selecting a planet.
+
+### Run the bot inside Docker
+
+This bot can be runned inside a docker container in headless mode.
+
+1. Get the gettoken.json file.
+2. Run the docker image:
+
+```
+docker run -v /path/to/gettoken.json:/app/gettoken.json meepen/salien-bot:latest
+```
+
+You also can run an autoupdated stack with the [example/docker-compose-autoupdate/docker-compose.yml](https://github.com/meepen/salien-bot/blob/master/examples/docker-compose-autoupdate/docker-compose.yml) configuration file.

--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ This bot can be ran inside a docker container in headless mode.
 docker run -v /path/to/gettoken.json:/app/gettoken.json meepen/salien-bot:latest
 ```
 
-You also can run an autoupdated stack with the [examples/docker-compose-autoupdate/docker-compose.yml](../blob/master/examples/docker-compose-autoupdate/docker-compose.yml) configuration file for [docker-compose](https://docs.docker.com/compose/).
+You also can run an autoupdated stack with the [examples/docker-compose-autoupdate/docker-compose.yml](../master/examples/docker-compose-autoupdate/docker-compose.yml) configuration file for [docker-compose](https://docs.docker.com/compose/).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This will make the bot only use the last planet which you were on and allows you
 
 ### Run the bot inside Docker
 
-This bot can be runned inside a docker container in headless mode.
+This bot can be ran inside a docker container in headless mode.
 
 1. Get the gettoken.json file.
 2. Run the docker image:
@@ -71,4 +71,4 @@ This bot can be runned inside a docker container in headless mode.
 docker run -v /path/to/gettoken.json:/app/gettoken.json meepen/salien-bot:latest
 ```
 
-You also can run an autoupdated stack with the [example/docker-compose-autoupdate/docker-compose.yml](https://github.com/meepen/salien-bot/blob/master/examples/docker-compose-autoupdate/docker-compose.yml) configuration file.
+You also can run an autoupdated stack with the [examples/docker-compose-autoupdate/docker-compose.yml](../blob/master/examples/docker-compose-autoupdate/docker-compose.yml) configuration file for [docker-compose](https://docs.docker.com/compose/).

--- a/examples/docker-compose-autoupdate/docker-compose.yml
+++ b/examples/docker-compose-autoupdate/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  bot:
+    image: meepen/salien-bot:latest
+    restart: always
+    volumes:
+     - ./gettoken.json:/app/gettoken.json
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+  updater:
+    image: v2tec/watchtower
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 300 --label-enable

--- a/examples/docker-compose-autoupdate/docker-compose.yml
+++ b/examples/docker-compose-autoupdate/docker-compose.yml
@@ -1,9 +1,11 @@
 version: '2'
+# Autoupdated stack
 services:
   bot:
     image: meepen/salien-bot:latest
     restart: always
     volumes:
+    # The gettoken.json file must be in the same dir as docker-compose.yml file
      - ./gettoken.json:/app/gettoken.json
     labels:
       com.centurylinklabs.watchtower.enable: "true"


### PR DESCRIPTION
Instructions added to the README

The example `docker-compose.yml` configuration file allows run the bot and an autoupdate daemon as a docker services stack.

@meepen, check the grammar of the README please, my English is not very good...