### PR TITLE
Add .dockerignore to avoid compromising the token

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+package-lock.json
+gettoken.json
+log.txt


### PR DESCRIPTION
Related to #87 as proposed by @denas96. This should not affect the builds on Docker Hub but may be useful when testing it locally.