### PR TITLE
Headless: Added username to log info

### DIFF
--- a/headless.js
+++ b/headless.js
@@ -425,6 +425,7 @@ const PrintInfo = function PrintInfo() {
     let info_lines = [];
     if (cl.gPlayerInfo) {
         let info = cl.gPlayerInfo;
+        info_lines.push(["Playing as", cl.gPlayerName]);
         info_lines.push(["Running for", FormatTimer(((Date.now() / 1000) | 0) - start_time)]);
         info_lines.push(["Current level", `${info.level} (${info.score} / ${info.next_level_score})`]);
         info_lines.push(["Exp since start", info.score - cl.gPlayerInfoOriginal.score]);


### PR DESCRIPTION
Added username to log info (as requested through issue #140) through the client grabbing the player name. It's done this way rather than grabbing the persona from the gettoken.json, because a direct token argument for the command line was implemented. Therefore, this would work with anyone.