### PR TITLE
Removal of forced leveling mode

### DIFF
--- a/index.user.js
+++ b/index.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Saliens bot
 // @namespace    http://tampermonkey.net/
-// @version      30
+// @version      31
 // @description  Beat all the saliens levels
 // @author       https://github.com/meepen/salien-bot
 // @match        https://steamcommunity.com/saliengame
@@ -19,7 +19,6 @@ if (typeof GM_info !== "undefined" && (GM_info.scriptHandler || "Greasemonkey") 
 (function(context) {
 "use strict";
 
-const MAX_LEVEL = 13;
 const BOSS_CHECK = 5; //Number of battles to check planets for a boss.
 
 // reload automatically instead of clicking ok
@@ -48,13 +47,6 @@ SERVER.ReportScore = function ReportScore(nScore, callback, error) {
     });
 }
 
-const Option = function Option(name, def) {
-    if (window.localStorage[name] === undefined) {
-        context.localStorage[name] = def;
-    }
-    return context.localStorage[name];
-}
-Option("forceLevellingMode", false);
 const SetMouse = function SetMouse(x, y) {
     APP.renderer.plugins.interaction.mouse.global.x = x;
     APP.renderer.plugins.interaction.mouse.global.y = y;
@@ -171,9 +163,7 @@ const CanAttack = function CanAttack(attackname) {
 const GetBestZone = function GetBestZone() {
     let bestZoneIdx;
     let highestDifficulty = -1;
-
-    let isLevelling = context.gPlayerInfo.level < MAX_LEVEL || Option("forceLevellingMode");
-    let maxProgress = isLevelling ? 10000 : 0;
+    let bestZoneProgress = 0;
 
     for (let idx = 0; idx < GAME.m_State.m_Grid.m_Tiles.length; idx++) {
         let zone = GAME.m_State.m_Grid.m_Tiles[idx].Info;
@@ -183,23 +173,15 @@ const GetBestZone = function GetBestZone() {
 
                 return idx;
             }
+            if(zone.difficulty > highestDifficulty) {
+                highestDifficulty = zone.difficulty;
+                bestZoneProgress = zone.progress;
+                bestZoneIdx = idx;
+            } else if(zone.difficulty < highestDifficulty) continue;
 
-            if(isLevelling) {
-                if(zone.difficulty > highestDifficulty) {
-                    highestDifficulty = zone.difficulty;
-                    maxProgress = zone.progress;
-                    bestZoneIdx = idx;
-                } else if(zone.difficulty < highestDifficulty) continue;
-
-                if(zone.progress < maxProgress) {
-                    maxProgress = zone.progress;
-                    bestZoneIdx = idx;
-                }
-            } else {
-                if(zone.progress > maxProgress) {
-                    maxProgress = zone.progress;
-                    bestZoneIdx = idx;
-                }
+            if(zone.progress < bestZoneProgress) {
+                bestZoneProgress = zone.progress;
+                bestZoneIdx = idx;
             }
 
         }
@@ -214,7 +196,8 @@ const GetBestZone = function GetBestZone() {
 const GetBestPlanet = function GetBestPlanet() {
     let bestPlanet;
     let bestPlanetIdx;
-    let maxProgress = 0;
+    let bestPlanetZoneDifficulty = -1;
+    let bestPlanetProgress = 10000;
 
     if (!GAME.m_State.m_mapPlanets)
         return;
@@ -225,8 +208,8 @@ const GetBestPlanet = function GetBestPlanet() {
             console.log(`selecting planet ${planet.state.name} with boss at (${planet.state.boss_zone_position.x},${planet.state.boss_zone_position.y}) progress: ${planet.state.capture_progress}`);
             return idx;
         }
-        if(planet.state.active && !planet.state.captured && planet.state.capture_progress > maxProgress) {
-            maxProgress = planet.state.capture_progress;
+        if(planet.state.active && !planet.state.captured && planet.state.capture_progress < bestPlanetProgress) {
+            bestPlanetProgress = planet.state.capture_progress;
             bestPlanet = planet;
             bestPlanetIdx = idx;
         }


### PR DESCRIPTION
Made with reference to changes discussed in PR #169

Leveling mode is now always enforced.
Removed MAX_LEVEL, forceLevellingMode flag and option storage function
Changed zone logic to always go for highest difficulty tiles first.
Changed planet selection logic to choose the least progressed planet in order to access higher difficulty tiles.
Renamed variables as we are not looking for the maximum, but the best logically.
Bumped version to 31